### PR TITLE
Updated flatten function that is executed at decoding to keep original value order of payload.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 _build
+_opam
 .merlin
 *.install
 *.docdir
 *.native
 *.byte
+*.swp
 

--- a/lib-test/test_jwto.ml
+++ b/lib-test/test_jwto.ml
@@ -13,6 +13,7 @@ let header_json =
 let payload_fixture =
   [
     ("user_id", "some@user.tld");
+    ("user_name", "user");
   ]
 
 let secret =
@@ -63,11 +64,11 @@ let data =
   [
     {
       alg = Jwto.HS256;
-      token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.kWOVtIOpWcG7JnyJG0qOkTDbOy636XrrQhMm_8JrRQ8";
+      token = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCIsInVzZXJfbmFtZSI6InVzZXIifQ.oWQQcNC80L91BVqJya8mSEKwB2-axLjDClVI1lOA85o";
     };
     {
       alg = Jwto.HS512;
-      token = "eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCJ9.8zNtCBTJIZTHpZ-BkhR-6sZY1K85Nm5YCKqV3AxRdsBJDt_RR-REH2db4T3Y0uQwNknhrCnZGvhNHrvhDwV1kA";
+      token = "eyJhbGciOiJIUzUxMiJ9.eyJ1c2VyX2lkIjoic29tZUB1c2VyLnRsZCIsInVzZXJfbmFtZSI6InVzZXIifQ.VzxiGtU2kDmUAl7P3TcK3GTOdmhrIlhkWTfv09j0qou5Z8LQ29QeqaF-XB4D1LYa0JCXSXlhSEeamFyEEcaNDA";
     };
   ]
 

--- a/lib/jwto.ml
+++ b/lib/jwto.ml
@@ -15,17 +15,17 @@ let map_option f option =
   | None -> None 
   | Some v -> Some (f v)
 
-let flatten list =
-  List.fold_left
-    (fun acc res ->
-      match acc with
-      | Error e -> Error e
-      | Ok values -> (
-        match res with 
-          | Error e -> Error e 
-          | Ok v -> Ok (v :: values) ) 
+let flatten (list: ('a, 'b) result list) =
+  List.fold_right
+    (fun item acm ->
+     match acm with
+     | Error e -> Error e
+     | Ok v1 ->
+       match item with
+       | Error e -> Error e
+       | Ok v2 -> Ok (v2 :: v1)
     )
-    (Ok []) list
+    list (Ok [])
 
 type algorithm =
   | HS256 

--- a/lib/jwto.ml
+++ b/lib/jwto.ml
@@ -20,10 +20,10 @@ let flatten (list: ('a, 'b) result list) =
     (fun item acm ->
      match acm with
      | Error e -> Error e
-     | Ok v1 ->
+     | Ok values ->
        match item with
        | Error e -> Error e
-       | Ok v2 -> Ok (v2 :: v1)
+       | Ok v -> Ok (v :: values)
     )
     list (Ok [])
 


### PR DESCRIPTION
Existing `flatten` creates a list contains values reverse order.

for example, 

```
[("key1", "value1"); ("key", "value2")]
```

will be
```
[("key", "value2"); ("key1", "value1")]
```
via flatten function.

so, some function has problem due this logic.
(I found at `is_valid`)

When execute `is_valid`, then Jwto recreate signature to compare with original signature that from user be sent.(JWT Token)
But payload that will be stringify to recreate signature  was already reversed a order via `flatten`
So original signature and recreated signature that is with the reversed Payload will be not unique.
I fixed this problem.